### PR TITLE
Remove stdout by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ By default, the configuration is:
         }
       },
       "addDate": true
-    },
-    "stdout": {
-      "level": "info",
-      "addDate": true
     }
   }
 }
@@ -53,9 +49,6 @@ That means:
  * Prefix logs with the date
  * Errors are written in a file `kuzzle-error.log`
  * Warnings are written in a file `kuzzle-warning.log`
-* We use the standard output
- * Prefix logs with the date
- * Info logs are displayed (via stdout)
 
 ## stdout
 

--- a/package.json
+++ b/package.json
@@ -35,10 +35,6 @@
             }
           },
           "addDate": true
-        },
-        "stdout": {
-          "level": "info",
-          "addDate": true
         }
       },
       "loadedBy": "all"


### PR DESCRIPTION
By default, Kuzzle is now shipped with a logger that will only write errors and warnings.
The user can still configure the plugin and add `stdout`.
