### PR TITLE
switching to 1 process per default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-logger",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Kuzzle plugin that handles logs",
   "main": "./lib/index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "pluginInfo": {
     "defaultConfig": {
-      "threads": 2,
+      "threads": 1,
       "services": {
         "file": {
           "outputs": {


### PR DESCRIPTION
For the time being, the default configuration for the logger is to use 2 processes.
Each process consumes around 65MB (cf below). Further, there is no need to scale loggers as they are likely io-bounded rather than limited by the CPU.

```
┌───────────────────────────┬─────┬─────────┬───────┬────────┬─────────┬────────┬─────────────┬──────────┐
│ App name                  │ id  │ mode    │ pid   │ status │ restart │ uptime │ memory      │ watching │
├───────────────────────────┼─────┼─────────┼───────┼────────┼─────────┼────────┼─────────────┼──────────┤
│ kpw:kuzzle-plugin-logger  │ 394 │ cluster │ 17485 │ online │ 0       │ 28m    │ 61.410 MB   │ disabled │
│ kpw:kuzzle-plugin-logger  │ 395 │ cluster │ 17490 │ online │ 0       │ 28m    │ 61.527 MB   │ disabled | 
└───────────────────────────┴─────┴─────────┴───────┴────────┴─────────┴────────┴─────────────┴──────────┘
```