### PR TITLE
Default config in plugin Code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,7 @@
 
 const
   hooks = require('./config/hooks'),
-  moment = require('moment'),
-  merge = require('lodash.merge');
+  moment = require('moment');
 
 module.exports = function Logger () {
   this.loggers = [];
@@ -25,8 +24,8 @@ module.exports = function Logger () {
           'level': 'info'
         }
       }
-    }
-    const config = merge({}, defaultConfig, customConfig);
+    };
+    const config = Object.assign(defaultConfig, customConfig);
 
     if (!config.services) {
       throw new Error('plugin-logger: The \'services\' attribute, with services configurations to use is required');

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,16 +2,31 @@
 
 const
   hooks = require('./config/hooks'),
-  moment = require('moment');
+  moment = require('moment'),
+  merge = require('lodash.merge');
 
 module.exports = function Logger () {
   this.loggers = [];
   this.isDummy = false;
 
-  this.init = function (config, context, isDummy) {
-    if (!config) {
-      throw new Error('plugin-logger: A configuration is required for plugin logger');
+  this.init = function (customConfig, context, isDummy) {
+    const defaultConfig = {
+      'services': {
+        'file': {
+          'outputs': {
+            'error': {
+              'level': 'warn',
+              'filename': 'kuzzle.log'
+            }
+          },
+          'addDate': true
+        },
+        'stdout': {
+          'level': 'info'
+        }
+      }
     }
+    const config = merge({}, defaultConfig, customConfig);
 
     if (!config.services) {
       throw new Error('plugin-logger: The \'services\' attribute, with services configurations to use is required');

--- a/package.json
+++ b/package.json
@@ -22,27 +22,9 @@
   "bugs": {
     "url": "https://github.com/kuzzleio/kuzzle-plugin-logger/issues"
   },
-  "pluginInfo": {
-    "defaultConfig": {
-      "threads": 1,
-      "services": {
-        "file": {
-          "outputs": {
-            "error": {
-              "level": "warn",
-              "filename": "kuzzle.log"
-            }
-          },
-          "addDate": true
-        },
-        "stdout": {
-          "level": "info"
-        }
-      }
-    }
-  },
   "license": "Apache-2.0",
   "dependencies": {
+    "lodash.merge": "^4.6.0",
     "moment": "^2.14.1",
     "winston": "2.2.0",
     "winston-syslog": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "lodash.merge": "^4.6.0",
     "moment": "^2.14.1",
     "winston": "2.2.0",
     "winston-syslog": "^1.2.1"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -50,14 +50,6 @@ describe('index', () => {
 
   describe('#init', () => {
 
-    it('should throw if no config is given', () => {
-      return should(() => plugin.init()).throw('plugin-logger: A configuration is required for plugin logger');
-    });
-
-    it('should throw if no services are configured', () => {
-      return should(() => plugin.init({})).throw('plugin-logger: The \'services\' attribute, with services configurations to use is required');
-    });
-
     it('should return the plugin if no error occurred', () => {
       var response = plugin.init({services: {}});
 


### PR DESCRIPTION
Adapts the plugin to the Apache-ish installation system specified in kuzzleio/kuzzle#609 

The plugin has now its own default config in its own code and can run with a `null` customConfig passed to the `init` function.

**Please note** that, after merging this PR, we should update the corresponding Git submodule in Kuzzle repository.