### PR TITLE
Fix default config and remove default file transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 4.2
+- 6.9
 before_script:
 - npm install -g grunt-cli
 notifications:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@ Currently, three winston transports are supported:
 * `syslog` (from [winston-syslog](https://www.npmjs.com/package/winston-syslog))
 
 
-## Manifest
-
-This plugin doesn't need any right.
-
 ## Configuration
+
+Each transport can be added and configured by adding it to the `services` entry.
+
+The content of this section is _almost_ passed as-is to `winston` related transport constructor.
+
+The only exception is `addDate` and `dateFormat` parameters, which are specific to Kuzzle and allow to specify a custom 
+date format using only plain-text configuration, using [moment format](http://momentjs.com/docs/#/displaying/format/).
+
+:warning: **Contrary to winston, it is not possible to pass a function to any option.**
 
 Sample:
 
@@ -27,7 +32,8 @@ Sample:
     "file": {
       "level": "warn",
       "filename": "kuzzle.log",
-      "addDate": true
+      "addDate": true,
+      "dateFormat": "dddd, MMMM Do YYYY, h:mm:ss a"
     },
     "stdout": {
       "level": "info",
@@ -42,22 +48,32 @@ Sample:
 }
 ```
 
-## stdout
+## Default configuration
 
-* **level**: maximal level to log (Default: `error`)
-* **addDate** `true|false` if set to true, prefix all logs with the current date (default: `true`)
-* **dateFormat**: A string in [moment format syntax](http://momentjs.com/docs/#/displaying/) used to format the prefixed date (Default: ISO8601: `YYYY-MM-DDTHH:mm:ssZ`).
+If no configuration is given, this plugin will output logs to the console only, from `info` level and above.
 
-## file
+## Transports configuration references
 
-* **level**: maximal level to log (Default: `error`)
-* **filename**: path of the log file (Default: `kuzzle.log`)
-* **addDate** `true|false` if set to true, prefix all logs with the current date (default: `true`)
-* **dateFormat**: A string in [moment format syntax](http://momentjs.com/docs/#/displaying/) used to format the prefixed date (Default: ISO8601: `YYYY-MM-DDTHH:mm:ssZ`).
+* [stdout](https://github.com/winstonjs/winston/blob/master/docs/transports.md#console-transport)
+* [file](https://github.com/winstonjs/winston/blob/master/docs/transports.md#file-transport)
+* [syslog](https://github.com/winstonjs/winston-syslog)
 
-## syslog
+## Date formatting
 
-In addition to the `level`, `addDate`, ans `dateFormat` parameter, the syslog configuration takes the same parameters as [winston-syslog](https://github.com/winstonjs/winston-syslog) module ones.
+Native `winston` date related/timestamp configurations are merged during the plugin init for transports that support it.
+
+In other words, `timestamp` and `addDate` can be used indifferently for `stdout` and `file` transports: 
+
+```json
+{
+  "services": {
+    "stdout": {
+      "timestamp": true,
+      "dateFormat": "YYYY-MM-DD HH-mm-ss"
+    }
+  }
+}
+```
 
 # How to create a plugin
 

--- a/lib/config/hooks.js
+++ b/lib/config/hooks.js
@@ -1,8 +1,0 @@
-module.exports = {
-  'log:silly': 'silly',
-  'log:verbose': 'verbose',
-  'log:info': 'info',
-  'log:debug': 'debug',
-  'log:warn': 'warn',
-  'log:error': 'error'
-};

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015 Kuzzle
+ * Copyright 2015-2017 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *
@@ -63,31 +63,31 @@ class Logger {
   }
 
   silly (message, event) {
-    let prepared = this._prepareMessage(message);
+    const prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('silly', event, prepared));
   }
 
   verbose (message, event) {
-    let prepared = this._prepareMessage(message);
+    const prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('verbose', event, prepared));
   }
 
   info (message, event) {
-    let prepared = this._prepareMessage(message);
+    const prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('info', event, prepared));
   }
 
   debug (message, event) {
-    let prepared = this._prepareMessage(message);
+    const prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('debug', event, prepared));
   }
 
   warn (message, event) {
-    let prepared = this._prepareMessage(message);
+    const prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('warn', event, prepared));
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,104 +1,98 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 const
-  hooks = require('./config/hooks'),
-  moment = require('moment');
+  services = require('./services');
 
-module.exports = function Logger () {
-  this.loggers = [];
-  this.isDummy = false;
+class Logger {
 
-  this.init = function (customConfig, context, isDummy) {
+  constructor () {
+    this.hooks = {
+      'log:silly': 'silly',
+      'log:verbose': 'verbose',
+      'log:info': 'info',
+      'log:debug': 'debug',
+      'log:warn': 'warn',
+      'log:error': 'error'
+    };
+    this.loggers = [];
+    this.winston = null;
+  }
+
+  init (config, context) {
     const defaultConfig = {
-      'services': {
-        'file': {
-          'outputs': {
-            'error': {
-              'level': 'warn',
-              'filename': 'kuzzle.log'
-            }
-          },
-          'addDate': true
-        },
-        'stdout': {
-          'level': 'info'
+      services: {
+        stdout: {
+          level: 'info',
+          showLevel: false
         }
       }
     };
-    const config = Object.assign(defaultConfig, customConfig);
+    const conf = Object.assign(defaultConfig, config);
 
-    if (!config.services) {
-      throw new Error('plugin-logger: The \'services\' attribute, with services configurations to use is required');
-    }
-
-    this.isDummy = isDummy;
-
-    Object.keys(config.services).forEach(serviceName => {
-      var logger = require('./services')(serviceName);
-      logger.init(config.services[serviceName], log);
+    Object.keys(conf.services).forEach(serviceName => {
+      if (!services[serviceName]) {
+        const InternalError = context.errors.InternalError;
+        throw new InternalError(`[kuzzle-plugin-logger] Unable to find service ${serviceName}`);
+      }
+      const logger = new services[serviceName](conf.services[serviceName]);
       this.loggers.push(logger);
     });
 
     return this;
-  };
+  }
 
-  this.hooks = hooks;
-
-  this.silly = function (message, event) {
-    let prepared = prepareMessage(message);
-
-    if (this.isDummy) {
-      return false;
-    }
+  silly (message, event) {
+    let prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('silly', event, prepared));
-  };
+  }
 
-  this.verbose = function (message, event) {
-    let prepared = prepareMessage(message);
-
-    if (this.isDummy) {
-      return false;
-    }
+  verbose (message, event) {
+    let prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('verbose', event, prepared));
-  };
+  }
 
-  this.info = function (message, event) {
-    let prepared = prepareMessage(message);
-
-    if (this.isDummy) {
-      return false;
-    }
+  info (message, event) {
+    let prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('info', event, prepared));
-  };
+  }
 
-  this.debug = function (message, event) {
-    let prepared = prepareMessage(message);
-
-    if (this.isDummy) {
-      return false;
-    }
+  debug (message, event) {
+    let prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('debug', event, prepared));
-  };
+  }
 
-  this.warn = function (message, event) {
-    let prepared = prepareMessage(message);
-
-    if (this.isDummy) {
-      return false;
-    }
+  warn (message, event) {
+    let prepared = this._prepareMessage(message);
 
     this.loggers.forEach(logger => logger.log('warn', event, prepared));
-  };
+  }
 
-  this.error = function (message, event) {
-    if (this.isDummy) {
-      return false;
-    }
-
+  error (message, event) {
     /*
      Pretty print Kuzzle errors.
      "instanceof" cannot be used here since error objects are
@@ -112,28 +106,22 @@ module.exports = function Logger () {
         this.loggers.forEach(logger => logger.log('error', event, `(${message.status}) ${message.message}`));
       }
     } else {
-      this.loggers.forEach(logger => logger.log('error', event, prepareMessage(message)));
+      this.loggers.forEach(logger => logger.log('error', event, this._prepareMessage(message)));
     }
-  };
-};
-
-function log (level, event, message) {
-  var prefix = `[${event.toUpperCase()}] `;
-
-  if (this.addDate) {
-    prefix = moment().format(this.dateFormat) +  ' ' + prefix;
   }
 
-  this.winston.log(level, prefix + message);
+  /**
+   * Since loggers only take strings as messages, we make sure this is
+   * what they receive. Otherwise, empty message log are printed.
+   *
+   * @private
+   * @param {*} message to log
+   * @return {string}
+   */
+  _prepareMessage(message) {
+    return (typeof message === 'string') ? message : JSON.stringify(message);
+  }
+
 }
 
-/**
- * Since loggers only take strings as messages, we make sure this is
- * what they receive. Otherwise, empty message log are printed.
- *
- * @param {*} message to log
- * @return {string}
- */
-function prepareMessage(message) {
-  return (typeof message === 'string') ? message : JSON.stringify(message);
-}
+module.exports = Logger;

--- a/lib/services/file.js
+++ b/lib/services/file.js
@@ -1,38 +1,53 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 let
-  moment = require('moment'),
+  Service = require('./service'),
   winston = require('winston');
 
-module.exports = {
-  winston: null,
-  addDate: false,
+class File extends Service {
 
-  init: function (config, log) {
+  constructor (config) {
+    const conf = Object.assign({
+      level: 'error',
+      filename: 'kuzzle.log'
+    }, config);
+    super(conf);
+
+    // default file transport sets timestamp to true
+    if (conf.addDate) {
+      this.addDate = true;
+    }
+    delete conf.addDate;
+    delete conf.dateFormat;
+
     this.winston = new (winston.Logger)({
       transports: [
-        new(winston.transports.File)({
-          json: false,
-          level: config.level || 'error',
-          filename: config.filename || 'kuzzle.log',
-          formatter: options => {
-            var line = `${options.level.toUpperCase()} ${options.message === undefined ? '-' : options.message} ` +
-                `${options.metadata ? JSON.stringify(options.metadata) : '-'}`;
-
-            if (config.addDate === undefined  || config.addDate) {
-              line = moment().format(config.dateFormat) + ' ' + line;
-            }
-
-            return line;
-          }
-        })
+        new winston.transports.File(conf)
       ]
     });
-
-    // handled at the formatter level
-    this.addDate = false;
-
-    this.log = log.bind(this);
   }
+}
 
-};
+module.exports = File;
+

--- a/lib/services/file.js
+++ b/lib/services/file.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015 Kuzzle
+ * Copyright 2015-2017 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015 Kuzzle
+ * Copyright 2015-2017 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *

--- a/lib/services/service.js
+++ b/lib/services/service.js
@@ -21,6 +21,29 @@
 
 'use strict';
 
-exports.file = require('./file');
-exports.stdout = require('./stdout');
-exports.syslog = require('./syslog');
+const
+  moment = require('moment');
+
+class Service {
+
+  constructor (config) {
+    this.config = config;
+
+    this.winston = null;
+    this.addDate = null;
+    this.dateFormat = this.config.dateFormat;
+  }
+
+  log (level, event, message) {
+    let prefix = `[${event.toUpperCase()}] `;
+
+    if (this.addDate) {
+      prefix = moment().format(this.dateFormat) +  ' ' + prefix;
+    }
+
+    this.winston.log(level, prefix + message);
+  }
+
+}
+
+module.exports = Service;

--- a/lib/services/service.js
+++ b/lib/services/service.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015 Kuzzle
+ * Copyright 2015-2017 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *

--- a/lib/services/stdout.js
+++ b/lib/services/stdout.js
@@ -1,21 +1,57 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
-let
+const
+  Service = require('./service'),
   winston = require('winston');
 
-module.exports = {
-  winston: null,
-  addDate: false,
+class StdOut extends Service {
 
-  init: function (config, log) {
+  constructor (config) {
+    let conf = Object.assign({
+      level: 'error'
+    }, config);
+
+    super(conf);
+
+    if (conf.timestamp) {
+      conf.addDate = true;
+      conf.timestamp = false;
+    }
+    this.addDate = (conf.addDate === undefined) || conf.addDate;
+
+    delete conf.addDate;
+    delete conf.dateFormat;
+
     this.winston = new (winston.Logger)({
       transports: [
-        new (winston.transports.Console)({ level: config.level || 'error' })
+        new (winston.transports.Console)(conf)
       ]
     });
 
-    this.addDate = (config.addDate === undefined) || config.addDate;
-    this.dateFormat = config.dateFormat;
-    this.log = log.bind(this);
   }
-};
+
+}
+
+module.exports = StdOut;
+

--- a/lib/services/stdout.js
+++ b/lib/services/stdout.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015 Kuzzle
+ * Copyright 2015-2017 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *
@@ -28,7 +28,7 @@ const
 class StdOut extends Service {
 
   constructor (config) {
-    let conf = Object.assign({
+    const conf = Object.assign({
       level: 'error'
     }, config);
 

--- a/lib/services/syslog.js
+++ b/lib/services/syslog.js
@@ -1,42 +1,54 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
-let
+const
+  Service = require('./service'),
   winston = require('winston');
 
 require('winston-syslog');
 
-module.exports = {
-  init: function (config, log) {
-    let transportOptions = {level: 'error'};
+class Syslog extends Service {
+
+  constructor (config) {
+    const conf = Object.assign({
+      level: 'error'
+    }, config);
+    super(conf);
+
+    this.addDate = (conf.addDate === undefined) || conf.addDate;
+    delete conf.addDate;
+    delete conf.dateFormat;
 
     winston.setLevels(winston.config.syslog.levels);
 
-    [
-      'level',
-      'host',
-      'port',
-      'protocol',
-      'path',
-      'pid',
-      'facility',
-      'localhost',
-      'type',
-      'app_name',
-      'eol'
-    ].forEach(opt => {
-      if (config[opt] !== undefined) {
-        transportOptions[opt] = config[opt];
-      }
-    });
-
     this.winston = new (winston.Logger)({
       transports: [
-        new (winston.transports.Syslog)(transportOptions)
+        new (winston.transports.Syslog)(conf)
       ]
     });
 
-    this.addDate = (config.addDate === undefined) || config.addDate;
-    this.dateFormat = config.dateFormat;
-    this.log = log.bind(this);
   }
-};
+
+}
+
+module.exports = Syslog;

--- a/lib/services/syslog.js
+++ b/lib/services/syslog.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015 Kuzzle
+ * Copyright 2015-2017 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *

--- a/package.json
+++ b/package.json
@@ -40,5 +40,7 @@
     "should-sinon": "0.0.5",
     "sinon": "^1.17.5"
   },
-  "_from": "kuzzle-plugin-logger@2.0.3"
+  "engines": {
+    "node": ">=6.9.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-logger",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Kuzzle plugin that handles logs",
   "main": "./lib/index.js",
   "scripts": {
@@ -24,6 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "kuzzle-common-objects": "^3.0.0",
     "moment": "^2.14.1",
     "winston": "2.2.0",
     "winston-syslog": "^1.2.1"
@@ -31,7 +32,9 @@
   "devDependencies": {
     "eslint": "3.5.0",
     "istanbul": "^0.4.4",
+    "kuzzle-common-objects": "^3.0.0",
     "mocha": "3.0.2",
+    "mock-require": "^2.0.2",
     "rewire": "^2.5.2",
     "should": "11.1.0",
     "should-sinon": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "kuzzle-common-objects": "^3.0.0",
     "moment": "^2.14.1",
     "winston": "2.2.0",
     "winston-syslog": "^1.2.1"
@@ -32,7 +31,6 @@
   "devDependencies": {
     "eslint": "3.5.0",
     "istanbul": "^0.4.4",
-    "kuzzle-common-objects": "^3.0.0",
     "mocha": "3.0.2",
     "mock-require": "^2.0.2",
     "rewire": "^2.5.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015 Kuzzle
+ * Copyright 2015-2017 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *
@@ -19,8 +19,16 @@
  * limitations under the License.
  */
 
+class InternalErrorMock extends Error {
+  constructor (msg) {
+    super(msg);
+
+    this.status = 500;
+    this.message = msg;
+  }
+}
+
 const
-  InternalError = require('kuzzle-common-objects').errors.InternalError,
   mock = require('mock-require'),
   should = require('should'),
   sinon = require('sinon');
@@ -34,10 +42,10 @@ describe('index', () => {
   beforeEach(() => {
     context = {
       errors: {
-        InternalError
+        InternalError: InternalErrorMock
       }
     };
-    Plugin = require('../lib'),
+    Plugin = require('../lib');
     plugin = new Plugin();
   });
 
@@ -78,7 +86,7 @@ describe('index', () => {
           }
         }
       }, context))
-        .throw(InternalError);
+        .throw(InternalErrorMock);
     });
 
     it('should return the plugin if no error occurred', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,35 +1,55 @@
-var
-  rewire = require('rewire'),
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const
+  InternalError = require('kuzzle-common-objects').errors.InternalError,
+  mock = require('mock-require'),
   should = require('should'),
-  sinon = require('sinon'),
-  Plugin = rewire('../lib'),
-  hooks = require('../lib/config/hooks');
+  sinon = require('sinon');
 
 describe('index', () => {
-  var
-    plugin;
+  let
+    Plugin,
+    plugin,
+    context;
 
   beforeEach(() => {
+    context = {
+      errors: {
+        InternalError
+      }
+    };
+    Plugin = require('../lib'),
     plugin = new Plugin();
   });
 
   describe('#constructor', () => {
     it('should implement all methods listed in hooks', () => {
-      Object.keys(hooks).forEach(k => {
-        should(plugin[hooks[k]]).be.a.Function();
-      });
-    });
-
-    it('all hook methods should return false if dummy', () => {
-      plugin.isDummy = true;
-
-      Object.keys(hooks).forEach(k => {
-        should(plugin[hooks[k]]()).be.false();
+      Object.keys(plugin.hooks).forEach(k => {
+        should(plugin[plugin.hooks[k]]).be.a.Function();
       });
     });
 
     it('all hook methods should call the loggers', () => {
-      Object.keys(hooks).forEach(k => {
+      Object.keys(plugin.hooks).forEach(k => {
         plugin = new Plugin();
 
         plugin.loggers = [
@@ -37,7 +57,7 @@ describe('index', () => {
           { log: sinon.spy() }
         ];
 
-        plugin[hooks[k]]('message', 'event');
+        plugin[plugin.hooks[k]]('message', 'event');
 
         plugin.loggers.forEach(logger => {
           should(logger.log).be.calledOnce();
@@ -50,80 +70,48 @@ describe('index', () => {
 
   describe('#init', () => {
 
+    it('should throw if the config references a non-existing transport', () => {
+      should(() => plugin.init({
+        services: {
+          nonexisting: {
+            foo: 'bar'
+          }
+        }
+      }, context))
+        .throw(InternalError);
+    });
+
     it('should return the plugin if no error occurred', () => {
-      var response = plugin.init({services: {}});
+      const response = plugin.init();
 
       should(response).be.an.instanceOf(Plugin);
+      should(plugin.loggers)
+        .be.an.Array()
+        .not.be.empty();
     });
 
     it('should init the services', () => {
-      var
-        log = Plugin.__get__('log'),
-        initSpy = sinon.spy();
+      const
+        spy = sinon.spy();
 
-      Plugin.__with__({
-        require: () => () => {
-          return {
-            init: initSpy
-          };
-        }
-      })(() => {
-        plugin.init({
-          services: {
-            test: {
-              foo: 'bar'
-            }
-          }
-        });
-
-        should(initSpy).be.calledOnce();
-        should(initSpy).be.calledWith({foo: 'bar'}, log);
+      mock('../lib/services', {
+        test: spy
       });
-    });
+      Plugin = mock.reRequire('../lib');
+      plugin = new Plugin();
 
-  });
-
-  describe('#log', () => {
-    var
-      context,
-      log = Plugin.__get__('log');
-
-    beforeEach(() => {
-      context = {
-        addDate: true,
-        winston: {
-          log: sinon.spy()
+      plugin.init({
+        services: {
+          test: {
+            foo: 'bar'
+          }
         }
-      };
+      });
+
+      should(spy).be.calledOnce();
+      should(spy).be.calledWith({foo: 'bar'});
     });
 
-    it('should prefix the log with some date if addDate is truthy', () => {
-      log.call(context, 'level', 'event', 'message');
-
-      should(context.winston.log).be.calledOnce();
-      should(context.winston.log.getCall(0).args[0]).be.exactly('level');
-      should(context.winston.log.getCall(0).args[1]).match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2} \[EVENT\] message/);
-    });
-
-    it('should prefix the log with some date formatted as requested is addDate is truthy', () => {
-      context.dateFormat = '____';
-
-      log.call(context, 'level', 'event', 'message');
-
-      should(context.winston.log).be.calledOnce();
-      should(context.winston.log.getCall(0).args[0]).be.exactly('level');
-      should(context.winston.log.getCall(0).args[1]).be.exactly('____ [EVENT] message');
-    });
-
-    it('should not prefix the log with some date if addDate is falsy', () => {
-      context.addDate = false;
-
-      log.call(context, 'level', 'event', 'message');
-
-      should(context.winston.log).be.calledOnce();
-      should(context.winston.log.getCall(0).args[0]).be.exactly('level');
-      should(context.winston.log.getCall(0).args[1]).be.exactly('[EVENT] message');
-    });
   });
 
 });

--- a/test/services/file.test.js
+++ b/test/services/file.test.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015 Kuzzle
+ * Copyright 2015-2017 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *

--- a/test/services/file.test.js
+++ b/test/services/file.test.js
@@ -1,60 +1,86 @@
-var
-  rewire = require('rewire'),
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const
+  mock = require('mock-require'),
   sinon = require('sinon'),
   should = require('should'),
-  serviceFile = rewire('../../lib/services/file');
+  Service = require('../../lib/services/service');
 
 describe('services/file', function () {
-  var
-    log = function () {
-    },
-    winstonMock,
-    reset;
+  let
+    ServiceFile,
+    serviceFile,
+    winstonMock;
 
   beforeEach(() => {
-    reset = serviceFile.__set__({
-      winston: {
-        Logger: sinon.spy(),
-        transports: {
-          File: sinon.stub().returnsArg(0)
-        }
+    winstonMock = {
+      Logger: sinon.spy(),
+      transports: {
+        File: sinon.stub().returnsArg(0)
       }
-    });
-    winstonMock = serviceFile.__get__('winston');
+    };
+    mock('winston', winstonMock);
+    ServiceFile = mock.reRequire('../../lib/services/file');
   });
 
-  afterEach(() => {
-    reset();
+  after(() => {
+    mock.stopAll();
+  });
+
+  it('should be an instance of Service', () => {
+    serviceFile = new ServiceFile({});
+    should(serviceFile).be.an.instanceof(Service);
   });
 
   it('should set default values if not provided', () => {
-    var transportArgs;
+    let transportArgs;
 
-    serviceFile.init({}, log);
+    serviceFile = new ServiceFile({});
 
-    should(serviceFile.addDate).be.false();
+    should(serviceFile.addDate).be.null();
     should(serviceFile.dateFormat).be.undefined();
-    should(serviceFile.log).be.eql(log.bind(serviceFile));
     should(winstonMock.Logger).be.calledOnce();
     should(winstonMock.transports.File).be.calledOnce();
 
     transportArgs = winstonMock.transports.File.firstCall.returnValue;
     should(transportArgs).match({
-      json: false,
       level: 'error',
       filename: 'kuzzle.log'
     });
-    should(transportArgs.formatter).be.a.Function();
   });
 
   it('should set the given options', () => {
-    var transportArgs;
+    let transportArgs;
 
-    serviceFile.init({level: 'debug', filename: 'test', addDate: 'addDate', dateFormat: 'dtTest'}, log);
+    serviceFile = new ServiceFile({
+      json: false,
+      level: 'debug', 
+      filename: 'test', 
+      addDate: 'addDate', 
+      dateFormat: 'dtTest'
+    });
 
-    should(serviceFile.addDate).be.false();
-    should(serviceFile.dateFormat).be.undefined();
-    should(serviceFile.log).be.eql(log.bind(serviceFile));
+    should(serviceFile.addDate).be.true();
+    should(serviceFile.dateFormat).be.eql('dtTest');
     should(winstonMock.Logger).be.calledOnce();
     should(winstonMock.transports.File).be.calledOnce();
 
@@ -64,7 +90,6 @@ describe('services/file', function () {
       level: 'debug',
       filename: 'test'
     });
-    should(transportArgs.formatter).be.a.Function();
   });
 
 });

--- a/test/services/stdout.test.js
+++ b/test/services/stdout.test.js
@@ -1,37 +1,42 @@
-var
-  rewire = require('rewire'),
+const
+  mock = require('mock-require'),
   sinon = require('sinon'),
   should = require('should'),
-  serviceStdout = rewire('../../lib/services/stdout');
+  Service = require('../../lib/services/service');
 
 describe('services/stdout', function () {
-  var
-    log = function () {},
+  let
     winstonMock,
-    reset;
+    ServiceStdout,
+    serviceStdout;
 
   beforeEach(() => {
-    reset = serviceStdout.__set__({
-      winston: {
-        Logger: sinon.spy(),
-        transports: {
-          Console: sinon.spy()
-        }
+    winstonMock = {
+      Logger: sinon.spy(),
+      transports: {
+        Console: sinon.spy()
       }
-    });
-    winstonMock = serviceStdout.__get__('winston');
+    };
+    mock('winston', winstonMock);
+    ServiceStdout = mock.reRequire('../../lib/services/stdout');
   });
 
-  afterEach(() => {
-    reset();
+  after(() => {
+    mock.stopAll();
+  });
+
+  it('should be an instance of Service', () => {
+    serviceStdout = new ServiceStdout({});
+
+    should(serviceStdout)
+      .be.an.instanceOf(Service);
   });
 
   it('should set the default values if none are provided', () => {
-    serviceStdout.init({}, log);
+    serviceStdout = new ServiceStdout({});
 
     should(serviceStdout.addDate).be.true();
     should(serviceStdout.dateFormat).be.undefined();
-    should(serviceStdout.log).be.eql(log.bind(serviceStdout));
     should(winstonMock.Logger).be.calledOnce();
     should(winstonMock.transports.Console).be.calledOnce();
     should(winstonMock.transports.Console).be.calledWith({
@@ -40,11 +45,10 @@ describe('services/stdout', function () {
   });
 
   it('should use the given parameters', () => {
-    serviceStdout.init({level: 'debug', addDate: 'addDate', dateFormat: 'dateFormat'}, log);
+    serviceStdout = new ServiceStdout({level: 'debug', addDate: 'addDate', dateFormat: 'dateFormat'});
 
     should(serviceStdout.addDate).be.exactly('addDate');
     should(serviceStdout.dateFormat).be.exactly('dateFormat');
-    should(serviceStdout.log).be.eql(log.bind(serviceStdout));
     should(winstonMock.Logger).be.calledOnce();
     should(winstonMock.transports.Console).be.calledOnce();
     should(winstonMock.transports.Console).be.calledWith({

--- a/test/services/stdout.test.js
+++ b/test/services/stdout.test.js
@@ -1,3 +1,24 @@
+/*
+ * Kuzzle, a backend software, self-hostable and ready to use
+ * to power modern apps
+ *
+ * Copyright 2015-2017 Kuzzle
+ * mailto: support AT kuzzle.io
+ * website: http://kuzzle.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const
   mock = require('mock-require'),
   sinon = require('sinon'),

--- a/test/services/syslog.test.js
+++ b/test/services/syslog.test.js
@@ -2,7 +2,7 @@
  * Kuzzle, a backend software, self-hostable and ready to use
  * to power modern apps
  *
- * Copyright 2015 Kuzzle
+ * Copyright 2015-2017 Kuzzle
  * mailto: support AT kuzzle.io
  * website: http://kuzzle.io
  *


### PR DESCRIPTION
# Description

* Fix default configuration, which was not injecting the proper format
* Remove the file transport by default, which possibly would cause disk space exhaustion risks
* Add License headers to prepare SonarCube integration
* All transports now accept all possible options (excepting functions for obvious reasons).

# Related issue

* #16