### PR TITLE
Release 2.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-logger",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Kuzzle plugin that handles logs",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
# [2.0.8](https://github.com/kuzzleio/kuzzle-plugin-logger/releases/tag/2.0.8) (2017-06-20)

### Compatibility

| Kuzzle | Proxy |
|--------|-------|
| rc.x | 1.0.0 |

#### Others

- [ [#17](https://github.com/kuzzleio/kuzzle-plugin-logger/pull/17) ] Fix default config and remove default file transport   ([benoitvidis](https://github.com/benoitvidis))
---

