### PR TITLE
Only output stack on error when enabled

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ class Logger {
      */
     if (message && typeof message === 'object' && message.message && message.status) {
       if (message.stack) {
-        this.loggers.forEach(logger => logger.log('error', event, `(${message.status}) ${message.message}\n${message.stack}`));
+        this.loggers.forEach(logger => logger.log('error', event, `(${message.status}) ${message.stack}`));
       }
       else {
         this.loggers.forEach(logger => logger.log('error', event, `(${message.status}) ${message.message}`));


### PR DESCRIPTION
Stack trace contains original error message, we don't have to write it twice