### PR TITLE
Release 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-plugin-logger",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Kuzzle plugin that handles logs",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
# [2.0.9](https://github.com/kuzzleio/kuzzle-plugin-logger/releases/tag/2.0.9) (2017-07-19)

### Compatibility

| Kuzzle | Proxy |
|--------|-------|
| 1.0.0 | 1.0.0 |

#### Others

- [ [#23](https://github.com/kuzzleio/kuzzle-plugin-logger/pull/23) ] Only output stack on error when enabled   ([stafyniaksacha](https://github.com/stafyniaksacha))
---

