### PR TITLE
Check file writing permission on plugin startup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,7 @@ class Logger {
         const InternalError = context.errors.InternalError;
         throw new InternalError(`[kuzzle-plugin-logger] Unable to find service ${serviceName}`);
       }
+
       const logger = new services[serviceName](conf.services[serviceName], context.errors);
       this.loggers.push(logger);
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ class Logger {
         const InternalError = context.errors.InternalError;
         throw new InternalError(`[kuzzle-plugin-logger] Unable to find service ${serviceName}`);
       }
-      const logger = new services[serviceName](conf.services[serviceName]);
+      const logger = new services[serviceName](conf.services[serviceName], context.errors);
       this.loggers.push(logger);
     });
 

--- a/lib/services/file.js
+++ b/lib/services/file.js
@@ -21,18 +21,29 @@
 
 'use strict';
 
-let
-  Service = require('./service'),
-  winston = require('winston');
+const Service = require('./service');
+const winston = require('winston');
+const fs = require('fs');
 
 class File extends Service {
 
-  constructor (config) {
+  constructor(config, kerror) {
+
     const conf = Object.assign(
       { level: 'error', filename: 'kuzzle.log' },
       config);
 
     super(conf);
+
+    try {
+      this.isWritableSync(config.filename);
+    } catch (error) {
+      if (error.code === 'EPERM') {
+        throw new kerror.PreconditionError(`[kuzzle-plugin-logger] EPERM, cannot open ${config.filename}`);
+      }
+
+      throw error;
+    }
 
     // default file transport sets timestamp to true
     if (conf.addDate) {
@@ -47,6 +58,12 @@ class File extends Service {
         new winston.transports.File(conf)
       ]
     });
+  }
+
+  isWritableSync(filePath) {
+    fs.statSync(filePath);
+    fs.accessSync(filePath, fs.W_OK | fs.R_OK);
+    fs.appendFileSync(filePath, '[kuzzle-plugin-logger] Started logging');
   }
 }
 

--- a/lib/services/file.js
+++ b/lib/services/file.js
@@ -35,16 +35,6 @@ class File extends Service {
 
     super(conf);
 
-    try {
-      this.isWritableSync(config.filename);
-    } catch (error) {
-      if (error.code === 'EPERM') {
-        throw new kerror.PreconditionError(`[kuzzle-plugin-logger] EPERM, cannot open ${config.filename}`);
-      }
-
-      throw error;
-    }
-
     // default file transport sets timestamp to true
     if (conf.addDate) {
       this.addDate = true;
@@ -58,6 +48,18 @@ class File extends Service {
         new winston.transports.File(conf)
       ]
     });
+
+    try {
+      if (config.filename) {
+        this.isWritableSync(config.filename);
+      }
+    } catch (error) {
+      if (error.code === 'EPERM') {
+        throw new kerror.PreconditionError(`[kuzzle-plugin-logger] EPERM, cannot open ${config.filename}`);
+      }
+
+      throw error;
+    }
   }
 
   isWritableSync(filePath) {

--- a/lib/services/file.js
+++ b/lib/services/file.js
@@ -49,20 +49,20 @@ class File extends Service {
       ]
     });
 
-    try {
-      if (config.filename) {
-        this.isWritableSync(config.filename);
-      }
-    } catch (error) {
-      if (error.code === 'EPERM') {
-        throw new kerror.PreconditionError(`[kuzzle-plugin-logger] EPERM, cannot open ${config.filename}`);
-      }
+    if (config.filename) {
+      try {
+        this.assertFile_OK(config.filename);
+      } catch (error) {
+        if (error.code === 'EPERM') {
+          throw new kerror.PreconditionError(`[kuzzle-plugin-logger] EPERM, cannot open ${config.filename}`);
+        }
 
-      throw error;
+        throw error;
+      }
     }
   }
 
-  isWritableSync(filePath) {
+  assertFile_OK(filePath) {
     fs.statSync(filePath);
     fs.accessSync(filePath, fs.W_OK | fs.R_OK);
     fs.appendFileSync(filePath, '[kuzzle-plugin-logger] Started logging');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1561,6 +1561,12 @@
         }
       }
     },
+    "mock-fs": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+      "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
+      "dev": true
+    },
     "mock-require": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -895,6 +895,11 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1409,7 +1414,8 @@
     },
     "lodash": {
       "version": "4.17.11",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "fs": "0.0.1-security",
     "moment": "^2.24.0",
     "triple-beam": "^1.3.0",
     "winston": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint": "6.6.0",
     "istanbul": "^0.4.5",
     "mocha": "6.2.2",
+    "mock-fs": "^4.13.0",
     "mock-require": "^3.0.3",
     "rewire": "^4.0.1",
     "should": "13.2.3",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,7 +20,7 @@
  */
 
 class InternalErrorMock extends Error {
-  constructor (msg) {
+  constructor(msg) {
     super(msg);
 
     this.status = 500;
@@ -85,8 +85,8 @@ describe('index', () => {
     });
 
     it('should properly pretty print non-error objects', () => {
-      plugin.error({foo: 'bar'}, 'event');
-      should(plugin._prepareMessage).calledOnce().calledWithMatch({foo: 'bar'});
+      plugin.error({ foo: 'bar' }, 'event');
+      should(plugin._prepareMessage).calledOnce().calledWithMatch({ foo: 'bar' });
       for (const logger of plugin.loggers) {
         should(logger.log)
           .calledOnce()
@@ -109,7 +109,7 @@ describe('index', () => {
     });
 
     it('should pretty print serialized plain Error objects with no stack', () => {
-      const error = {message: 'foobar'};
+      const error = { message: 'foobar' };
 
       plugin.error(error, 'event');
 
@@ -137,7 +137,7 @@ describe('index', () => {
     });
 
     it('should pretty print serialized Kuzzle errors', () => {
-      const error = {message: 'foobar', status: 500};
+      const error = { message: 'foobar', status: 500 };
 
       plugin.error(error, 'event');
 
@@ -165,7 +165,7 @@ describe('index', () => {
     });
 
     it('should return the plugin if no error occurred', () => {
-      const response = plugin.init();
+      const response = plugin.init({}, context);
 
       should(response).be.an.instanceOf(Plugin);
       should(plugin.loggers)
@@ -174,12 +174,9 @@ describe('index', () => {
     });
 
     it('should init the services', () => {
-      const
-        spy = sinon.spy();
+      const spy = sinon.spy();
 
-      mock('../lib/services', {
-        test: spy
-      });
+      mock('../lib/services', { test: spy });
       Plugin = mock.reRequire('../lib');
       plugin = new Plugin();
 
@@ -188,11 +185,11 @@ describe('index', () => {
           test: {
             foo: 'bar'
           }
-        }
-      });
+        },
+      }, context);
 
       should(spy).be.calledOnce();
-      should(spy).be.calledWith({foo: 'bar'});
+      should(spy).be.calledWith({ foo: 'bar' });
     });
 
   });

--- a/test/services/file.test.js
+++ b/test/services/file.test.js
@@ -19,11 +19,12 @@
  * limitations under the License.
  */
 
-const
-  mock = require('mock-require'),
-  sinon = require('sinon'),
-  should = require('should'),
-  Service = require('../../lib/services/service');
+const mock = require('mock-require');
+const sinon = require('sinon');
+const should = require('should');
+const Service = require('../../lib/services/service');
+const fs = require('fs');
+
 
 describe('services/file', function () {
   let
@@ -74,7 +75,6 @@ describe('services/file', function () {
     serviceFile = new ServiceFile({
       json: false,
       level: 'debug',
-      filename: 'test',
       addDate: 'addDate',
       dateFormat: 'dtTest'
     });
@@ -88,8 +88,30 @@ describe('services/file', function () {
     should(transportArgs).match({
       json: false,
       level: 'debug',
-      filename: 'test'
+      filename: 'kuzzle.log'
     });
+  });
+
+  it('should log Error if file does not exits', () => {
+    try {
+      serviceFile = new ServiceFile({
+        filename: './log/kuzzle.log'
+      });
+    } catch (error) {
+      should(error).be.an.Error();
+    }
+  });
+
+  it('should init correctly if file exists', () => {
+    fs.mkdirSync('./log');
+    fs.writeFileSync('./log/kuzzle.log', 'init');
+
+    serviceFile = new ServiceFile({
+      filename: './log/kuzzle.log'
+    });
+
+    fs.unlinkSync('./log/kuzzle.log');
+    fs.rmdirSync('./log');
   });
 
 });

--- a/test/services/file.test.js
+++ b/test/services/file.test.js
@@ -23,16 +23,16 @@ const mock = require('mock-require');
 const sinon = require('sinon');
 const should = require('should');
 const Service = require('../../lib/services/service');
-const fs = require('fs');
+const mockFs = require('mock-fs');
 
 
 describe('services/file', function () {
-  let
-    ServiceFile,
-    serviceFile,
-    winstonMock;
+  let ServiceFile;
+  let serviceFile;
+  let winstonMock;
 
   beforeEach(() => {
+    /** winstonMock */
     winstonMock = {
       createLogger: sinon.spy(),
       transports: {
@@ -40,6 +40,8 @@ describe('services/file', function () {
       }
     };
     mock('winston', winstonMock);
+
+    /** ServiceFile */
     ServiceFile = mock.reRequire('../../lib/services/file');
   });
 
@@ -103,15 +105,15 @@ describe('services/file', function () {
   });
 
   it('should init correctly if file exists', () => {
-    fs.mkdirSync('./log');
-    fs.writeFileSync('./log/kuzzle.log', 'init');
+    mockFs({
+      './log/kuzzle.log': 'This is some test data put into a test file'
+    });
 
     serviceFile = new ServiceFile({
       filename: './log/kuzzle.log'
     });
 
-    fs.unlinkSync('./log/kuzzle.log');
-    fs.rmdirSync('./log');
+    mockFs.restore();
   });
 
 });

--- a/test/services/file.test.js
+++ b/test/services/file.test.js
@@ -32,7 +32,6 @@ describe('services/file', function () {
   let winstonMock;
 
   beforeEach(() => {
-    /** winstonMock */
     winstonMock = {
       createLogger: sinon.spy(),
       transports: {

--- a/test/services/file.test.js
+++ b/test/services/file.test.js
@@ -40,7 +40,6 @@ describe('services/file', function () {
     };
     mock('winston', winstonMock);
 
-    /** ServiceFile */
     ServiceFile = mock.reRequire('../../lib/services/file');
   });
 


### PR DESCRIPTION
This PR  is linked to this issue #37 

Fix #37 

Little weird that for some reason In some cases fs.access does not work, you need to write something in it to spawn the error.

How to test this:

1. `kourou app:scaffold sandbox`
1. git clone this repo and checkout to my branch

Use this docker-compose

```yaml
version: "3"

services:
  kuzzle:
    build:
      dockerfile: Dockerfile
      context: docker/
      target: kuzzle-dev
    command: npm run dev
    user: kuzzle
    stdin_open: true
    cap_add:
      - SYS_PTRACE
    ulimits:
      nofile: 65536
    sysctls:
      - net.core.somaxconn=8192
    volumes:
      - .:/var/app
      - /var/log/kuzzle:/var/log/kuzzle
      - <your-kuzzle-plugin-logger-path-goes-here>:/var/app/node_modules/kuzzle-plugin-logger
    ports:
      - "7512:7512"
      - "9229:9229"
      - "1883:1883"
    depends_on:
      - redis
    environment:
      - kuzzle_services__storageEngine__client__node=http://elasticsearch:9200
      - kuzzle_services__storageEngine__commonMapping__dynamic=true
      - kuzzle_services__internalCache__node__host=redis
      - kuzzle_services__memoryStorage__node__host=redis
      - NODE_ENV=${NODE_ENV:-development}
      - DEBUG=${DEBUG:-none}
      # - DEBUG=${DEBUG:-kuzzle:*,-kuzzle:entry-point:protocols:websocket,-kuzzle:cluster:heartbeat}

  redis:
    image: redis:5

  elasticsearch:
    image: kuzzleio/elasticsearch:7
    ulimits:
      nofile: 65536
```

Add this config into your `kuzzlerc`

```json
{
  "plugins": {
    "kuzzle-plugin-logger": {
      "services": {
        "file": {
          "level": "warn",
          "filename": "/var/log/kuzzle/kuzzle.log",
          "addDate": true
        }
      }
    }
  }
}
```

1. mkdir -p /var/log/kuzzle/
1. sudo touch /var/log/kuzzle/kuzzle.log
1. chmod 600 /var/log/kuzzle/kuzzle.log

1. run `docker-compose up`