### PR TITLE
Update Winston Syslog version from 2.3.0 to 2.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,11 +165,6 @@
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
-    "atomic-sleep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -826,11 +821,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-redact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
-    },
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
@@ -893,11 +883,6 @@
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
-    },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
       "version": "2.0.1",
@@ -1834,24 +1819,6 @@
         }
       }
     },
-    "pino": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.0.tgz",
-      "integrity": "sha512-VPqEE2sU1z6wqkTtr7DdTktayTNE/JgeuWjfXh9g/TI6X7venzv4gaoU24/jSywf6bBeDfZRHWEeO/6f8bNppA==",
-      "requires": {
-        "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.7",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
-        "quick-format-unescaped": "^4.0.1",
-        "sonic-boom": "^1.0.2"
-      }
-    },
-    "pino-std-serializers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.1.1.tgz",
-      "integrity": "sha512-Ud4+WzgEr/swOlfQdkxqKP2hlwuQlIqQ5YwYpo9MczNg2mpsKKyKgwQXW5KnP5tgH3/Cy9QRhAhLM8k1K+gfnA=="
-    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -1886,11 +1853,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "quick-format-unescaped": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -2406,15 +2368,6 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
-      }
-    },
-    "sonic-boom": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
-      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
-      "requires": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
       }
     },
     "source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,6 +165,11 @@
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -471,11 +476,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "debug": {
       "version": "4.1.1",
@@ -826,6 +826,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-redact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
+      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
+    },
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
@@ -888,6 +893,11 @@
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
+    },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
       "version": "2.0.1",
@@ -1409,7 +1419,8 @@
     },
     "lodash": {
       "version": "4.17.11",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "log-symbols": {
@@ -1582,9 +1593,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
     },
     "natural-compare": {
@@ -1823,6 +1834,24 @@
         }
       }
     },
+    "pino": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.0.tgz",
+      "integrity": "sha512-VPqEE2sU1z6wqkTtr7DdTktayTNE/JgeuWjfXh9g/TI6X7venzv4gaoU24/jSywf6bBeDfZRHWEeO/6f8bNppA==",
+      "requires": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.1.1.tgz",
+      "integrity": "sha512-Ud4+WzgEr/swOlfQdkxqKP2hlwuQlIqQ5YwYpo9MczNg2mpsKKyKgwQXW5KnP5tgH3/Cy9QRhAhLM8k1K+gfnA=="
+    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -1857,6 +1886,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -2374,6 +2408,15 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "sonic-boom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
+      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
+      }
+    },
     "source-map": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
@@ -2601,6 +2644,16 @@
         }
       }
     },
+    "unix-dgram": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.3.tgz",
+      "integrity": "sha512-Bay5CkSLcdypcBCsxvHEvaG3mftzT5FlUnRToPWEAVxwYI8NI/8zSJ/Gknlp86MPhV6hBA8I8TBsETj2tssoHQ==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -2687,25 +2740,12 @@
       }
     },
     "winston-syslog": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/winston-syslog/-/winston-syslog-2.3.0.tgz",
-      "integrity": "sha512-1zOucrdeWb6ZcitFutoYEAU3VcoqAcjeBOkB4rM5ZivwGVzi6ppQJUsD3avCbsO1jv+TyU/zgpi11NOps6Tjqg==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston-syslog/-/winston-syslog-2.4.4.tgz",
+      "integrity": "sha512-zDjoKO932Yszvzq8WtbIFMXHwAT2MOxpWC9s6djw2tvjdRESWw3au6l+0xDMatMhNWVoVaVNkDXF+r/eyoBUVA==",
       "requires": {
-        "cycle": "^1.0.3",
         "glossy": "^0.1.7",
-        "unix-dgram": "2.0.2"
-      },
-      "dependencies": {
-        "unix-dgram": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.2.tgz",
-          "integrity": "sha512-QdKFZWzQ+cn9GloYcFw5Yp2DT7JyS5aAgMJPossiOwljrjQPqM8cOaJvkD+9aZhIVZ45OHonCvLWjm3l8fSNoA==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.3.0",
-            "nan": "^2.10.0"
-          }
-        }
+        "unix-dgram": "2.0.3"
       }
     },
     "winston-transport": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "moment": "^2.24.0",
-    "pino": "^6.11.0",
     "triple-beam": "^1.3.0",
     "winston": "^3.2.1",
     "winston-syslog": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "moment": "^2.24.0",
+    "pino": "^6.11.0",
     "triple-beam": "^1.3.0",
     "winston": "^3.2.1",
-    "winston-syslog": "2.3.0",
+    "winston-syslog": "2.4.4",
     "winston-transport": "^4.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`unix-dgram` compilation errors have been fix since `winston-syslog` 2.4.0 so let's update it.

Required for https://github.com/kuzzleio/kuzzle/issues/1680